### PR TITLE
Fix max 500 pins pagination error

### DIFF
--- a/src/IpfsPinSync.js
+++ b/src/IpfsPinSync.js
@@ -70,7 +70,7 @@ export default class IpfsPinSync {
         let pinList = [];
 
         while (pinsExistToCheck === true) {
-            // Get 1000 Successful Pins
+            // Get 500 Successful Pins
             let pinsGetOptions = {
                 limit: 500,
                 status: new Set([Status.Pinned, Status.Pinning, Status.Queued]) // requires a set, and not an array
@@ -87,7 +87,7 @@ export default class IpfsPinSync {
             earliestPinInList = this.#getOldestPinCreateDate(results)
 
             console.log(`Results Length: ${results.size}`)
-            if (results.size !== 1000) {
+            if (results.size !== 500) {
                 pinsExistToCheck = false;
             }
         }


### PR DESCRIPTION
Turns out that there was a mismatch between `500` and `1000` preventing the code from properly paginating.

This pr fixes it.