### PR TITLE
Add delay when paginating to prevent pinata rate limit

### DIFF
--- a/src/IpfsPinSync.js
+++ b/src/IpfsPinSync.js
@@ -70,7 +70,7 @@ export default class IpfsPinSync {
         let pinList = [];
 
         while (pinsExistToCheck === true) {
-            // Get 1000 Successful Pins
+            // Get 500 Successful Pins
             let pinsGetOptions = {
                 limit: 500,
                 status: new Set([Status.Pinned, Status.Pinning, Status.Queued]) // requires a set, and not an array
@@ -87,7 +87,7 @@ export default class IpfsPinSync {
             earliestPinInList = this.#getOldestPinCreateDate(results)
 
             console.log(`Results Length: ${results.size}`)
-            if (results.size !== 1000) {
+            if (results.size !== 500) {
                 pinsExistToCheck = false;
             }
         }

--- a/src/IpfsPinSync.js
+++ b/src/IpfsPinSync.js
@@ -84,6 +84,9 @@ export default class IpfsPinSync {
             console.log(count, results)
             pinList = pinList.concat(Array.from(results));
 
+            // Add delay when paginating to prevent pinata rate limit
+            await new Promise(r => setTimeout(r, 20_000));
+
             earliestPinInList = this.#getOldestPinCreateDate(results)
 
             console.log(`Results Length: ${results.size}`)


### PR DESCRIPTION
I'm not sure we want to merge this, but it shows how to add a delay between each request to avoid the pinata rate limit.

Can take many minutes or more to get the whole list.

There are probably better refactors to take to improve how this library processes long lists.